### PR TITLE
Bugfix

### DIFF
--- a/lib/mt940/base.rb
+++ b/lib/mt940/base.rb
@@ -41,7 +41,7 @@ module MT940
     private
 
     def begin_of_line?(line)
-      line.match /^:|^940|^0000\s|^ABNA/
+      line.match /^:\d{2}F?:|^940|^0000\s|^ABNA/
     end
 
     def parse_tag_25


### PR DESCRIPTION
Made begin_of_line coherent with line matcher in parse method.
It can happen that the description is exported to multiple lines. When this happens in the middle op a time (20\n:41 instead of 20:41) the description and transaction data get out of sync. This fix prevents this.
